### PR TITLE
ext: allow configuring url to backend

### DIFF
--- a/wikiweaver-ext/common/background.js
+++ b/wikiweaver-ext/common/background.js
@@ -1,5 +1,4 @@
-const domain = "https://wikiweaver.stuffontheinter.net"; // Use this for production
-// const domain = "http://localhost:4242"; // Use this for local development
+const defaultdomain = "https://wikiweaver.stuffontheinter.net";
 
 function Matches(url, filters) {
   for (let filter of filters) {
@@ -123,7 +122,7 @@ async function SendPage(previousPage, currentPage, backmove = false) {
     backmove: backmove,
   };
 
-  return await SendPOSTRequestToServer("/api/ext/page", body);
+  return await SendPOSTRequestToServer(options.url, "/api/ext/page", body);
 }
 
 async function HandleMessageConnect(msg) {
@@ -136,7 +135,7 @@ async function HandleMessageConnect(msg) {
     userid: userid,
   };
 
-  const response = await SendPOSTRequestToServer("/api/ext/join", body);
+  const response = await SendPOSTRequestToServer(options.url, "/api/ext/join", body);
 
   if (response.Success) {
     await SetPageCount(0);
@@ -168,10 +167,13 @@ chrome.runtime.onMessage.addListener(async (msg) => {
   }
 });
 
-async function SendPOSTRequestToServer(endpoint, body) {
+async function SendPOSTRequestToServer(url, endpoint, body) {
   console.log("sent:", body);
 
-  let response = await fetch(`${domain}${endpoint}`, {
+  if (url === "") {
+    url = defaultdomain;
+  }
+  let response = await fetch(`${url}${endpoint}`, {
     method: "POST",
     body: JSON.stringify(body),
   })

--- a/wikiweaver-ext/common/popup/popup.html
+++ b/wikiweaver-ext/common/popup/popup.html
@@ -13,9 +13,9 @@
       <img id="logo" src="../icons/48.png" height="48" width="48" />
       <span id="title" class="text">WikiWeaver</span>
     </div>
-    <div id="explanation-text" class="text"> Go to the
-      <a href="https://wikiweaver.stuffontheinter.net/">WikiWeaver website</a>
-      to create a lobby and enter that code here to join it
+    <input id="url" class="box text" placeholder="https://wikiweaver.stuffontheinter.net"></input>
+    <div id="explanation-text" class="text"> Go to your
+      WikiWeaver website to create a lobby and enter the URL and code here to join it.
     </div>
     <div id="connected-text" class="text" hidden>Connected to lobby</div>
     <input id="code" class="box text" placeholder="code" maxlength="4"></input>

--- a/wikiweaver-ext/common/popup/popup.js
+++ b/wikiweaver-ext/common/popup/popup.js
@@ -1,6 +1,10 @@
 async function init() {
   const options = await chrome.storage.local.get();
 
+  if (options.url != undefined) {
+    document.getElementById("url").value = options.url;
+  }
+
   if (options.code != undefined) {
     document.getElementById("code").value = options.code;
   }
@@ -58,10 +62,12 @@ async function UpdateBadgeColor(success) {
 async function HandleJoinClicked(e) {
   const codeElem = document.getElementById("code");
   const usernameElem = document.getElementById("username");
+  const urlElem = document.getElementById("url");
 
   await chrome.storage.local.set({
     code: codeElem.value.toLowerCase(),
     username: usernameElem.value,
+    url: urlElem.value.toLowerCase(),
   });
 
   IndicateConnectionStatus({ status: "pending" });


### PR DESCRIPTION
users may want to host the backend themselves. changing the url used by wikiweaver-web is easy since only the host needs to change it, but all players would need to re-compile the extension. with this pr, users can put a custom url to another backend. the original wikiweaver.stuffontheinter.net is used as a default.

it might be necessary to change the font size a bit since URLs can get pretty wide. i'm not very good at UX.