### PR TITLE
Open start page automatically when starting lobby

### DIFF
--- a/wikiweaver-ext/background.js
+++ b/wikiweaver-ext/background.js
@@ -150,13 +150,16 @@ async function HandleMessageConnect(msg) {
 
     // Server sent event reference: https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events
     eventSource = new EventSource(`${options.url}/api/ext/events?code=${options.code}&userid=${response.UserID}`);
-    eventSource.addEventListener("start", (e) => {
+    eventSource.addEventListener("start", async (e) => {
       const data = JSON.parse(e.data);
+      const options = await chrome.storage.local.get();
 
-      chrome.tabs.create({
-        active: true,
-        url: Urlify(data.StartPage)
-      })
+      if (options.autoOpenStartPage) {
+        chrome.tabs.create({
+          active: true,
+          url: Urlify(data.StartPage)
+        })
+      }
     });
   }
 
@@ -342,5 +345,6 @@ chrome.runtime.onInstalled.addListener(async () => {
   let options = await chrome.storage.local.get();
 
   const url = options.url || defaultdomain;
-  await chrome.storage.local.set({ url });
+  const autoOpenStartPage = options.autoOpenStartPage || true;
+  await chrome.storage.local.set({ url, autoOpenStartPage });
 });

--- a/wikiweaver-ext/background.js
+++ b/wikiweaver-ext/background.js
@@ -188,9 +188,6 @@ chrome.runtime.onMessage.addListener(async (msg) => {
 async function SendPOSTRequestToServer(url, endpoint, body) {
   console.log("sent:", body);
 
-  if (url === "") {
-    url = defaultdomain;
-  }
   let response = await fetch(`${url}${endpoint}`, {
     method: "POST",
     body: JSON.stringify(body),
@@ -340,3 +337,10 @@ async function UpdateBadge(success) {
   chrome.action.setBadgeBackgroundColor({ color: color });
   chrome.action.setBadgeText({ text: String(await GetPageCount()) });
 }
+
+chrome.runtime.onInstalled.addListener(async () => {
+  let options = await chrome.storage.local.get();
+
+  const url = options.url || defaultdomain;
+  await chrome.storage.local.set({ url });
+});

--- a/wikiweaver-ext/background.js
+++ b/wikiweaver-ext/background.js
@@ -1,5 +1,7 @@
 const defaultdomain = "https://wikiweaver.stuffontheinter.net";
 
+var eventSource = null;
+
 function Matches(url, filters) {
   for (let filter of filters) {
     if (url.match(filter)) {
@@ -140,6 +142,22 @@ async function HandleMessageConnect(msg) {
   if (response.Success) {
     await SetPageCount(0);
     await SetUserIdForLobby(options.code, response.UserID);
+
+    if (eventSource != null) {
+      eventSource.close();
+      eventSource = null;
+    }
+
+    // Server sent event reference: https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events
+    eventSource = new EventSource(`${options.url}/api/ext/events?code=${options.code}&userid=${response.UserID}`);
+    eventSource.addEventListener("start", (e) => {
+      const data = JSON.parse(e.data);
+
+      chrome.tabs.create({
+        active: true,
+        url: Urlify(data.StartPage)
+      })
+    });
   }
 
   await UpdateBadge(response.Success);
@@ -188,6 +206,11 @@ async function SendPOSTRequestToServer(url, endpoint, body) {
   return response;
 }
 
+function Urlify(InString) {
+  // Turns an id back into a URL
+  return "https://en.wikipedia.org/wiki/" + InString
+}
+
 async function GetWikipediaArticleTitle(url) {
   title = decodeURIComponent(url)
     .split("/")
@@ -214,14 +237,14 @@ async function SearchForWikipediaTitle(title) {
   };
 
   url = url + "?origin=*";
-  Object.keys(params).forEach(function (key) {
+  Object.keys(params).forEach(function(key) {
     url += "&" + key + "=" + params[key];
   });
 
   response = await fetch(url)
     .then((response) => response.json())
     .then((json) => json)
-    .catch(function (error) {
+    .catch(function(error) {
       return { error: error };
     });
 

--- a/wikiweaver-ext/background.js
+++ b/wikiweaver-ext/background.js
@@ -154,6 +154,8 @@ async function HandleMessageConnect(msg) {
       const data = JSON.parse(e.data);
       const options = await chrome.storage.local.get();
 
+      chrome.storage.session.set({ startPage: data.StartPage });
+
       if (options.autoOpenStartPage) {
         chrome.tabs.create({
           active: true,

--- a/wikiweaver-ext/options/options.html
+++ b/wikiweaver-ext/options/options.html
@@ -18,6 +18,14 @@
           <input id="url" placeholder="https://wikiweaver.stuffontheinter.net" />
         </td>
       </tr>
+      <tr>
+        <td>
+          <input type="checkbox" id="auto-open-start-page" checked>
+        </td>
+        <td>
+          <label for="auto-open-start">Automatically open start page when host starts lobby</label>
+        </td>
+      </tr>
     </table>
     <button class="box button" id="submit" type="submit">Save</button>
   </form>

--- a/wikiweaver-ext/options/options.html
+++ b/wikiweaver-ext/options/options.html
@@ -23,7 +23,7 @@
           <input type="checkbox" id="auto-open-start-page" checked>
         </td>
         <td>
-          <label for="auto-open-start">Automatically open start page when host starts lobby</label>
+          <label for="auto-open-start">Automatically open first page on game start</label>
         </td>
       </tr>
     </table>

--- a/wikiweaver-ext/options/options.js
+++ b/wikiweaver-ext/options/options.js
@@ -4,15 +4,19 @@ async function init(e) {
 
 async function restore() {
   const options = await chrome.storage.local.get()
-  document.querySelector("#url").value = options.url || "";
+  document.querySelector("#url").value = options.url;
 }
 
 async function save(e) {
   e.preventDefault();
-  await chrome.storage.local.set({
-    url: document.querySelector("#url").value.toLowerCase(),
-  });
-  // todo: show saved succeeded in some way
+
+  const urlElem = document.querySelector("#url");
+
+  const url = new URL(urlElem.value.toLowerCase() || urlElem.placeholder);
+
+  await chrome.storage.local.set({ url: url.origin });
+  // TODO: show saved succeeded in some way
+
 }
 
 document.addEventListener("DOMContentLoaded", () => init(), false);

--- a/wikiweaver-ext/options/options.js
+++ b/wikiweaver-ext/options/options.js
@@ -11,12 +11,18 @@ async function save(e) {
   e.preventDefault();
 
   const urlElem = document.querySelector("#url");
+  const autoOpenElem = document.querySelector("#auto-open-start-page");
 
   const url = new URL(urlElem.value.toLowerCase() || urlElem.placeholder);
 
-  await chrome.storage.local.set({ url: url.origin });
-  // TODO: show saved succeeded in some way
+  await chrome.storage.local.set(
+    {
+      url: url.origin,
+      autoOpenStartPage: autoOpenElem.checked,
+    }
+  );
 
+  // TODO: show saved succeeded in some way
 }
 
 document.addEventListener("DOMContentLoaded", () => init(), false);

--- a/wikiweaver-ext/popup/popup.html
+++ b/wikiweaver-ext/popup/popup.html
@@ -27,6 +27,10 @@
       open lobby
       <span class="material-symbols-outlined">open_in_new</span>
     </button>
+    <button id="open-start-page" class="button box text">
+      open start page
+      <span class="material-symbols-outlined">open_in_new</span>
+    </button>
     <button id="open-settings" class="button box text">
       open settings
       <span class="material-symbols-outlined">open_in_new</span>

--- a/wikiweaver-ext/popup/popup.html
+++ b/wikiweaver-ext/popup/popup.html
@@ -28,7 +28,7 @@
       <span class="material-symbols-outlined">open_in_new</span>
     </button>
     <button id="open-start-page" class="button box text">
-      open start page
+      open first page
       <span class="material-symbols-outlined">open_in_new</span>
     </button>
     <button id="open-settings" class="button box text">

--- a/wikiweaver-ext/popup/popup.js
+++ b/wikiweaver-ext/popup/popup.js
@@ -1,5 +1,6 @@
 async function init() {
   const options = await chrome.storage.local.get();
+  const session = await chrome.storage.session.get();
 
   if (options.code != undefined) {
     document.getElementById("code").value = options.code;
@@ -9,7 +10,9 @@ async function init() {
     document.getElementById("username").value = options.username;
   }
 
-  if ((await chrome.storage.session.get()).connected) {
+  document.getElementById("open-start-page").disabled = !session.startPage;
+
+  if (session.connected) {
     // If we think we are connected, attempt to join again just to make sure
     await HandleJoinClicked();
   } else {
@@ -93,6 +96,22 @@ async function HandleOpenLobbyClicked(e) {
   })
 }
 
+function Urlify(InString) {
+  // Turns an id back into a URL
+  return "https://en.wikipedia.org/wiki/" + InString
+}
+
+async function HandleStartPageClicked(e) {
+  const session = await chrome.storage.session.get();
+
+  if (session.startPage) {
+    chrome.tabs.create({
+      active: true,
+      url: Urlify(session.startPage),
+    })
+  }
+}
+
 document.addEventListener("click", async (e) => {
   switch (e.target.id) {
     case "join":
@@ -105,6 +124,10 @@ document.addEventListener("click", async (e) => {
 
     case "open-lobby":
       await HandleOpenLobbyClicked(e);
+      break;
+
+    case "open-start-page":
+      await HandleStartPageClicked(e);
       break;
 
     case "open-settings":


### PR DESCRIPTION
Solves #11 

Use server-sent events to automatically open the start page when the host starts the lobby. Since they are one-sided, keep them alive as long the lobby is alive. If an extension joins a different lobby, it automatically closes its current eventstream (which the server wont know about) and wont receive any updates from the old lobby.