### PR TITLE
Add 'open lobby'-button to extension

### DIFF
--- a/wikiweaver-ext/popup/popup.html
+++ b/wikiweaver-ext/popup/popup.html
@@ -23,6 +23,10 @@
     <input id="username" class="box text" placeholder="username" maxlength="12"></input>
     <button id="join" class="button box text">join</button>
     <button id="leave" class="button box text">leave</button>
+    <button id="open-lobby" class="button box text">
+      open lobby
+      <span class="material-symbols-outlined">open_in_new</span>
+    </button>
     <button id="open-settings" class="button box text">
       open settings
       <span class="material-symbols-outlined">open_in_new</span>

--- a/wikiweaver-ext/popup/popup.js
+++ b/wikiweaver-ext/popup/popup.js
@@ -82,6 +82,17 @@ async function HandleLeaveClicked(e) {
   await UnregisterContentScripts();
 }
 
+async function HandleOpenLobbyClicked(e) {
+  const options = await chrome.storage.local.get();
+
+  let code = (await chrome.storage.session.get()).connected ? options.code : "";
+
+  await chrome.tabs.create({
+    active: true,
+    url: `${options.url}/#${code}`,
+  })
+}
+
 document.addEventListener("click", async (e) => {
   switch (e.target.id) {
     case "join":
@@ -92,12 +103,16 @@ document.addEventListener("click", async (e) => {
       await HandleLeaveClicked(e);
       break;
 
+    case "open-lobby":
+      await HandleOpenLobbyClicked(e);
+      break;
+
     case "open-settings":
       await chrome.runtime.openOptionsPage();
       break;
 
     default:
-      console.log("Unhandled click event: ", e);
+      // Quietly ignore
       break;
   }
 });

--- a/wikiweaver-ext/popup/style.css
+++ b/wikiweaver-ext/popup/style.css
@@ -58,7 +58,7 @@ body {
   background: var(--red);
 }
 
-#open-settings {
+#open-lobby {
   margin-top: 0.5rem;
 }
 


### PR DESCRIPTION
Fixes #22 

Add a button which will open a new lobby in case the user is not connected to any at the moment, otherwise it will open the lobby the user is currently connected to.

![image](https://github.com/user-attachments/assets/ae9926b8-48a7-429e-8b01-ac2b5e466175)
