### PR TITLE
Reference latest docker image instead of main

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ docker run -d \
   --restart unless-stopped \
   -p 80:80 \
   -e TZ='Europe/Stockholm' \
-  ghcr.io/stuffontheinternet/wikiweaver:main
+  ghcr.io/stuffontheinternet/wikiweaver:latest
 ```
 
 ### docker-compose
@@ -46,7 +46,7 @@ docker run -d \
 services:
   wikiweaver:
     container_name: wikiweaver
-    image: ghcr.io/stuffontheinternet/wikiweaver:main
+    image: ghcr.io/stuffontheinternet/wikiweaver:latest
     ports:
       - 80:80
     environment:
@@ -55,7 +55,6 @@ services:
 ```
 
 ## Local development
-
 
 ### Webserver and backend
 


### PR DESCRIPTION
Main will be the last push to the main branch, while latest is the latest tagged release. You usually want to update the server in conjuction with browser extension, otherwise they might be incompatible. Its a lot safer to reference the latest release, although there is a short window where one of them (server/extension) might be updated before the other during a release. Dont know what to do about that.