### PR TITLE
Add "join lobby"-button

### DIFF
--- a/wikiweaver-ext/background.js
+++ b/wikiweaver-ext/background.js
@@ -170,9 +170,6 @@ chrome.runtime.onMessage.addListener(async (msg) => {
 async function SendPOSTRequestToServer(url, endpoint, body) {
   console.log("sent:", body);
 
-  if (url === "") {
-    url = defaultdomain;
-  }
   let response = await fetch(`${url}${endpoint}`, {
     method: "POST",
     body: JSON.stringify(body),
@@ -214,14 +211,14 @@ async function SearchForWikipediaTitle(title) {
   };
 
   url = url + "?origin=*";
-  Object.keys(params).forEach(function (key) {
+  Object.keys(params).forEach(function(key) {
     url += "&" + key + "=" + params[key];
   });
 
   response = await fetch(url)
     .then((response) => response.json())
     .then((json) => json)
-    .catch(function (error) {
+    .catch(function(error) {
       return { error: error };
     });
 
@@ -317,3 +314,10 @@ async function UpdateBadge(success) {
   chrome.action.setBadgeBackgroundColor({ color: color });
   chrome.action.setBadgeText({ text: String(await GetPageCount()) });
 }
+
+chrome.runtime.onInstalled.addListener(async () => {
+  let options = await chrome.storage.local.get();
+
+  const url = options.url || defaultdomain;
+  await chrome.storage.local.set({ url });
+});

--- a/wikiweaver-ext/content/join-lobby.js
+++ b/wikiweaver-ext/content/join-lobby.js
@@ -1,0 +1,31 @@
+const fragment = document.createDocumentFragment();
+
+const div = document.createElement("div");
+div.classList.add("flex-horizontal-container")
+
+// TODO: There is probably a better way to do all this
+const btn = document.createElement("btn");
+btn.id = "join-lobby";
+btn.classList.add("button", "box", "text");
+btn.onclick = HandleJoinLobbyClicked;
+btn.style = "margin-top: 0.5rem; background: var(--green);";
+btn.textContent = "join";
+
+const reference = document.getElementById("leaderboard-wrapper");
+const parent = document.getElementById("sidepane");
+
+fragment.appendChild(div);
+div.appendChild(btn);
+parent.insertBefore(fragment, reference);
+
+async function HandleJoinLobbyClicked() {
+  const { username } = await chrome.storage.local.get();
+
+  let code = window.location.hash.replace("#", "").toLocaleLowerCase().trim();
+
+  await chrome.runtime.sendMessage({
+    type: "connect",
+    code,
+    username,
+  });
+}

--- a/wikiweaver-ext/manifest-chrome.json
+++ b/wikiweaver-ext/manifest-chrome.json
@@ -16,6 +16,7 @@
     "default_popup": "popup/popup.html"
   },
   "permissions": [
+    "activeTab",
     "scripting",
     "storage",
     "tabs",

--- a/wikiweaver-ext/manifest-firefox.json
+++ b/wikiweaver-ext/manifest-firefox.json
@@ -15,6 +15,7 @@
     "default_popup": "popup/popup.html"
   },
   "permissions": [
+    "activeTab",
     "scripting",
     "storage",
     "tabs",

--- a/wikiweaver-ext/options/options.js
+++ b/wikiweaver-ext/options/options.js
@@ -17,6 +17,23 @@ async function save(e) {
   await chrome.storage.local.set({ url: url.origin });
   // TODO: show saved succeeded in some way
 
+  if ((await chrome.scripting.getRegisteredContentScripts({ ids: ["join-lobby"] })).length > 0) {
+    await chrome.scripting.unregisterContentScripts({ ids: ["join-lobby"] });
+  }
+
+  // For some reason keeping the port here made it so the script was not
+  // injected at localhost, when the server was set to http://localhost:3000
+  url.port = "";
+
+  const scripts = [
+    {
+      id: "join-lobby",
+      js: ["/content/join-lobby.js"],
+      matches: [`${url.origin}/*`],
+    }
+  ]
+
+  await chrome.scripting.registerContentScripts(scripts);
 }
 
 document.addEventListener("DOMContentLoaded", () => init(), false);

--- a/wikiweaver-ext/options/options.js
+++ b/wikiweaver-ext/options/options.js
@@ -4,15 +4,19 @@ async function init(e) {
 
 async function restore() {
   const options = await chrome.storage.local.get()
-  document.querySelector("#url").value = options.url || "";
+  document.querySelector("#url").value = options.url;
 }
 
 async function save(e) {
   e.preventDefault();
-  await chrome.storage.local.set({
-    url: document.querySelector("#url").value.toLowerCase(),
-  });
-  // todo: show saved succeeded in some way
+
+  const urlElem = document.querySelector("#url");
+
+  const url = new URL(urlElem.value.toLowerCase() || urlElem.placeholder);
+
+  await chrome.storage.local.set({ url: url.origin });
+  // TODO: show saved succeeded in some way
+
 }
 
 document.addEventListener("DOMContentLoaded", () => init(), false);

--- a/wikiweaver-ext/popup/popup.js
+++ b/wikiweaver-ext/popup/popup.js
@@ -65,7 +65,16 @@ async function HandleJoinClicked(e) {
   });
 
   IndicateConnectionStatus({ status: "pending" });
-  await chrome.runtime.sendMessage({ type: "connect" });
+
+  const { code, username } = await chrome.storage.local.get();
+
+  await chrome.runtime.sendMessage(
+    {
+      type: "connect",
+      code,
+      username,
+    }
+  );
 }
 
 async function HandleLeaveClicked(e) {
@@ -118,6 +127,9 @@ async function HandleMessageConnect(msg) {
   } else {
     await UnregisterContentScripts();
   }
+
+  document.getElementById("code").textContent = msg.Code;
+  document.getElementById("username").textContent = msg.Username;
 }
 
 chrome.runtime.onMessage.addListener(async (msg) => {
@@ -143,13 +155,15 @@ const ContentScripts = [
 ];
 
 async function RegisterContentScripts() {
-  if ((await chrome.scripting.getRegisteredContentScripts()).length <= 0) {
+  if ((await chrome.scripting.getRegisteredContentScripts({ ids: ["content"] })).length <= 0) {
     await chrome.scripting.registerContentScripts(ContentScripts);
   }
 }
 
 async function UnregisterContentScripts() {
-  await chrome.scripting.unregisterContentScripts();
+  if ((await chrome.scripting.getRegisteredContentScripts({ ids: ["content"] })).length > 0) {
+    await chrome.scripting.unregisterContentScripts({ ids: ["content"] });
+  }
 }
 
 function EnableElements(elements) {

--- a/wikiweaver-server/cmd/main/wikiweaver-server.go
+++ b/wikiweaver-server/cmd/main/wikiweaver-server.go
@@ -629,6 +629,8 @@ type JoinFromExtRequest struct {
 
 type JoinToExtResponse struct {
 	Success        bool
+	Code           string
+	Username       string
 	UserID         string
 	AlreadyInLobby bool
 }
@@ -713,6 +715,8 @@ func handleExtJoin(w http.ResponseWriter, r *http.Request) {
 			if otherWithSameUsername.UserID == request.UserID || globalState.Dev {
 				successResponse := JoinToExtResponse{
 					Success:        true,
+					Code:           lobby.Code,
+					Username:       otherWithSameUsername.Username,
 					UserID:         request.UserID,
 					AlreadyInLobby: true,
 				}
@@ -777,6 +781,8 @@ func handleExtJoin(w http.ResponseWriter, r *http.Request) {
 
 		successResponse := JoinToExtResponse{
 			Success:        true,
+			Code:           lobby.Code,
+			Username:       extClient.Username,
 			UserID:         userID,
 			AlreadyInLobby: false,
 		}


### PR DESCRIPTION
Fixes #21 

Dynamically adds a join lobby button to the website by the browser extension on the domain specified in wikiweaver server. Hopefully frontend/backend is hosted on the same domain, but we could extend this later if we need that.

Note that you must have the browser extension open on for the permissions to kick in, it wont be able to insert the button otherwise. More on that in the commit message.