### PR TITLE
Keep connection status up-to-date between web server and extension

### DIFF
--- a/wikiweaver-ext/background.js
+++ b/wikiweaver-ext/background.js
@@ -174,6 +174,20 @@ async function HandleMessageConnect(msg) {
   });
 }
 
+async function HandleMessageDisconnect(msg) {
+  const options = await chrome.storage.local.get();
+  const userid = await GetUserIdForLobby(options.code);
+
+  const body = {
+    code: options.code,
+    username: options.username,
+    userid: userid,
+  };
+
+  // TODO: Right now we dont care about the response
+  await SendPOSTRequestToServer(options.url, "/api/ext/leave", body);
+}
+
 chrome.runtime.onMessage.addListener(async (msg) => {
   switch (msg.type) {
     case "connect":

--- a/wikiweaver-ext/background.js
+++ b/wikiweaver-ext/background.js
@@ -143,26 +143,29 @@ async function HandleMessageConnect(msg) {
     await SetPageCount(0);
     await SetUserIdForLobby(options.code, response.UserID);
 
-    if (eventSource != null) {
-      eventSource.close();
-      eventSource = null;
-    }
+    if (!response.AlreadyInLobby) {
 
-    // Server sent event reference: https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events
-    eventSource = new EventSource(`${options.url}/api/ext/events?code=${options.code}&userid=${response.UserID}`);
-    eventSource.addEventListener("start", async (e) => {
-      const data = JSON.parse(e.data);
-      const options = await chrome.storage.local.get();
-
-      chrome.storage.session.set({ startPage: data.StartPage });
-
-      if (options.autoOpenStartPage) {
-        chrome.tabs.create({
-          active: true,
-          url: Urlify(data.StartPage)
-        })
+      if (eventSource != null) {
+        eventSource.close();
+        eventSource = null;
       }
-    });
+
+      // Server sent event reference: https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events
+      eventSource = new EventSource(`${options.url}/api/ext/events?code=${options.code}&userid=${response.UserID}`);
+      eventSource.addEventListener("start", async (e) => {
+        const data = JSON.parse(e.data);
+        const options = await chrome.storage.local.get();
+
+        chrome.storage.session.set({ startPage: data.StartPage });
+
+        if (options.autoOpenStartPage) {
+          chrome.tabs.create({
+            active: true,
+            url: Urlify(data.StartPage)
+          })
+        }
+      });
+    }
   }
 
   await UpdateBadge(response.Success);

--- a/wikiweaver-ext/popup/popup.js
+++ b/wikiweaver-ext/popup/popup.js
@@ -83,6 +83,8 @@ async function HandleLeaveClicked(e) {
   EnableElements(elements);
 
   await UnregisterContentScripts();
+
+  await chrome.runtime.sendMessage({ type: "disconnect" });
 }
 
 async function HandleOpenLobbyClicked(e) {

--- a/wikiweaver-server/cmd/main/wikiweaver-server.go
+++ b/wikiweaver-server/cmd/main/wikiweaver-server.go
@@ -136,6 +136,14 @@ func (l *Lobby) removeWebClient(wcToRemove *WebClient) {
 	}
 }
 
+func (l *Lobby) RemoveExtClient(ecToRemove *ExtClient) {
+	for i := len(l.ExtClients) - 1; i >= 0; i-- {
+		if l.ExtClients[i] == ecToRemove {
+			l.ExtClients = append(l.ExtClients[:i], l.ExtClients[i+1:]...)
+		}
+	}
+}
+
 func (l *Lobby) GetExtClientFromUsername(usernameToCheck string) *ExtClient {
 	for _, extClient := range l.ExtClients {
 		if usernameToCheck == extClient.Username {
@@ -831,6 +839,88 @@ func handleExtJoin(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+type LeaveFromExtRequest struct {
+	Code     string
+	Username string
+	UserID   string
+}
+
+type LeaveToExtResponse struct {
+	Success bool
+}
+
+type LeaveToWebMessage struct {
+	Message
+	Username string
+}
+
+func handleExtLeave(w http.ResponseWriter, r *http.Request) {
+	failResponse := LeaveToExtResponse{
+		Success: false,
+	}
+
+	switch r.Method {
+	case http.MethodPost:
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			log.Printf("error reading extension request: %s", err)
+			SendResponseToExt(w, failResponse)
+			return
+		}
+
+		var request LeaveFromExtRequest
+		err = json.Unmarshal(body, &request)
+		if err != nil {
+			log.Printf("failed to parse message from extension: %s: '%s'", err, body)
+			SendResponseToExt(w, failResponse)
+			return
+		}
+
+		lobby := globalState.Lobbies[request.Code]
+
+		if lobby == nil {
+			log.Printf("extension %s tried to leave non-existing lobby %s", r.RemoteAddr, request.Code)
+			SendResponseToExt(w, failResponse)
+			return
+		}
+
+		lobby.mu.Lock()
+		defer lobby.mu.Unlock()
+
+		extClient := lobby.GetExtClientFromUsername(request.Username)
+
+		if extClient == nil {
+			log.Printf("extension %s tried to leave, but username %s is not in lobby %s", r.RemoteAddr, request.Username, request.Code)
+			SendResponseToExt(w, failResponse)
+			return
+		}
+
+		if extClient.UserID != request.UserID {
+			log.Printf("extension %s tried to leave, but username %s in lobby %s has userid %s, while extension has %s", r.RemoteAddr, request.Username, request.Code, extClient.UserID, request.UserID)
+			SendResponseToExt(w, failResponse)
+			return
+		}
+
+		delete(globalState.UserIDs, extClient.UserID)
+		lobby.RemoveExtClient(extClient)
+
+		log.Printf("extension %s left lobby %s as %s", r.RemoteAddr, request.Code, request.Username)
+
+		successResponse := LeaveToExtResponse{
+			Success: true,
+		}
+		SendResponseToExt(w, successResponse)
+
+		leaveToWebMessage := LeaveToWebMessage{
+			Message: Message{
+				Type: "leave",
+			},
+			Username: request.Username,
+		}
+		lobby.BroadcastToWeb(leaveToWebMessage)
+	}
+}
+
 type PageFromExtRequest struct {
 	Code     string
 	Username string
@@ -1083,6 +1173,7 @@ func main() {
 	http.HandleFunc("/api/ws/web/join", handleWebJoin)
 
 	http.HandleFunc("/api/ext/join", handleExtJoin)
+	http.HandleFunc("/api/ext/leave", handleExtLeave)
 	http.HandleFunc("/api/ext/page", handleExtPage)
 	http.HandleFunc("/api/ext/events", handleExtEvents)
 

--- a/wikiweaver-web/js/index.js
+++ b/wikiweaver-web/js/index.js
@@ -9,7 +9,7 @@ const LobbyState = Object.freeze({
   SHOWING_EXAMPLE: 0,
   RESET: 1,
   RACING: 2,
-  INDLE: 3,
+  IDLE: 3,
 })
 
 var DebounceTimeouts = {};

--- a/wikiweaver-web/js/index.js
+++ b/wikiweaver-web/js/index.js
@@ -310,16 +310,20 @@ function template_leaderboard_entries() {
     return -((t1 !== t2 ? t1 < t2 : p1.username < p2.username) * 2 - 1);
   }
 
-
-  return Object.values(players).toSorted(PlayerSort).map(({ username, clicks, pages, finishTime, color }) => {
+  return Object.values(players).toSorted(PlayerSort).map(({ username, clicks, pages, finishTime, color, connected }) => {
     function Time() {
       return finishTime ? FormatTime(finishTime) : "--:--";
+    }
+
+    function Strikethrough(p, text) {
+      if (p) return `<s>${text}</s>`;
+      return text;
     }
 
     return `
   <tr>
     <td data-cell="color" style="color: ${CMap[color].bgcolor}">⬤</td>
-    <td data-cell="username">${username}</td>
+    <td data-cell="username">${Strikethrough(!connected, username)}</td>
     <td data-cell="clicks">${clicks}</td>
     <td data-cell="pages">${pages}</td>
     <td data-cell="time">${Time()}</td>
@@ -381,6 +385,7 @@ document.addEventListener("reef:signal", async (event) => {
           break;
 
         case LobbyState.RACING:
+          RemoveDisconnectedPlayers();
           ResetPagePlaceholderTimer();
           break;
       }
@@ -582,7 +587,6 @@ function ResetStartAndGoalPages() {
 function UpdateLeaderboard(username, clicks, pages, finishTime) {
   let player = data.players[username];
 
-
   if (!player) {
     player = { username, color: UsernameToColor(username) };
     data.players[username] = player;
@@ -591,6 +595,7 @@ function UpdateLeaderboard(username, clicks, pages, finishTime) {
   player.clicks = clicks;
   player.pages = pages;
   player.finishTime = finishTime;
+  player.connected = true;
 }
 
 function ResetLeaderboardScores() {
@@ -603,6 +608,14 @@ function ResetLeaderboardScores() {
 
 function NumberOfPlayersFinished() {
   return Object.values(data.players).filter(p => p.finishTime).length;
+}
+
+function RemoveDisconnectedPlayers() {
+  const ps = Object.values(data.players).filter(p => !p.connected);
+  for ({ username } of ps) {
+    RemovePlayer(username);
+    delete data.players[username];
+  }
 }
 
 // ==== COUNTDOWN ===== 

--- a/wikiweaver-web/js/networking.js
+++ b/wikiweaver-web/js/networking.js
@@ -23,6 +23,12 @@ function HandleMessageJoin(msg) {
   UpdateLeaderboard(msg.Username, msg.Clicks, msg.Pages, msg.FinishTime);
 }
 
+function HandleMessageLeave(msg) {
+  console.log(`user ${msg.Username} left lobby`);
+  // TODO: Remove from leaderboard. Implement after reef js stuff is merged,
+  // it becomes a lot easier then
+}
+
 function HandleMessageLobby(msg) {
   data.code = msg.Code;
   data.connectionStatus = ConnectionStatus.CONNECTED;
@@ -99,6 +105,9 @@ async function JoinLobby() {
       case "join":
         HandleMessageJoin(msg);
         break;
+
+      case "leave":
+        HandleMessageLeave(msg);
 
       case "lobby":
         HandleMessageLobby(msg);

--- a/wikiweaver-web/js/networking.js
+++ b/wikiweaver-web/js/networking.js
@@ -24,9 +24,11 @@ function HandleMessageJoin(msg) {
 }
 
 function HandleMessageLeave(msg) {
-  console.log(`user ${msg.Username} left lobby`);
-  // TODO: Remove from leaderboard. Implement after reef js stuff is merged,
-  // it becomes a lot easier then
+  for (player of Object.values(data.players)) {
+    if (player.username == msg.Username) {
+      player.connected = false;
+    }
+  }
 }
 
 function HandleMessageLobby(msg) {
@@ -108,6 +110,7 @@ async function JoinLobby() {
 
       case "leave":
         HandleMessageLeave(msg);
+        break;
 
       case "lobby":
         HandleMessageLobby(msg);


### PR DESCRIPTION
The extension now notifies the server when it leaves the lobby by pressing the button. This is forwarded to the web client, although it is currently not handled. I plan to implement it using reef.js when it is merged later.