### PR TITLE
Implement simple library to handle settings

### DIFF
--- a/wikiweaver-ext/manifest-chrome.json
+++ b/wikiweaver-ext/manifest-chrome.json
@@ -25,9 +25,11 @@
     "*://*.wikipedia.org/*"
   ],
   "background": {
+    "type": "module",
     "service_worker": "background.js"
   },
   "options_ui": {
     "page": "options/options.html"
-  }
+  },
+  "minimum_chrome_version": "92"
 }

--- a/wikiweaver-ext/manifest-firefox.json
+++ b/wikiweaver-ext/manifest-firefox.json
@@ -24,6 +24,7 @@
     "*://*.wikipedia.org/*"
   ],
   "background": {
+    "type": "module",
     "scripts": [
       "background.js"
     ]

--- a/wikiweaver-ext/options/options.html
+++ b/wikiweaver-ext/options/options.html
@@ -5,6 +5,7 @@
 <head>
   <meta charset="utf-8" />
   <link rel="stylesheet" href="style.css">
+  <script type="module" src="../settings.js"></script>
 </head>
 
 <body>

--- a/wikiweaver-ext/options/options.js
+++ b/wikiweaver-ext/options/options.js
@@ -1,26 +1,26 @@
+let Settings;
+
 async function init(e) {
+  const settings = await import('../settings.js');
+  Settings = settings.Settings;
+
   await restore();
 }
 
 async function restore() {
-  const options = await chrome.storage.local.get()
-  document.querySelector("#url").value = options.url;
+  const { url, autoOpenStartPage } = await Settings.local.Get();
+
+  document.querySelector("#url").value = url;
+  document.querySelector("#auto-open-start-page").checked = autoOpenStartPage;
 }
 
 async function save(e) {
   e.preventDefault();
 
   const urlElem = document.querySelector("#url");
-  const autoOpenElem = document.querySelector("#auto-open-start-page");
 
-  const url = new URL(urlElem.value.toLowerCase() || urlElem.placeholder);
-
-  await chrome.storage.local.set(
-    {
-      url: url.origin,
-      autoOpenStartPage: autoOpenElem.checked,
-    }
-  );
+  await Settings.local.Set("url", urlElem.value.toLowerCase() || urlElem.placeholder);
+  await Settings.local.Set("autoOpenStartPage", document.querySelector("#auto-open-start-page").checked);
 
   // TODO: show saved succeeded in some way
 }

--- a/wikiweaver-ext/popup/popup.html
+++ b/wikiweaver-ext/popup/popup.html
@@ -4,6 +4,7 @@
 <head>
   <meta charset="UTF-8">
   <link rel="stylesheet" href="style.css">
+  <script type="module" src="../settings.js"></script>
   <script type="text/javascript" src="popup.js"></script>
   <link rel="stylesheet"
     href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0&icon_names=open_in_new" />

--- a/wikiweaver-ext/settings.js
+++ b/wikiweaver-ext/settings.js
@@ -1,0 +1,51 @@
+export const Settings = {
+  "local": StorageAPI(chrome.storage.local),
+  "session": StorageAPI(chrome.storage.session),
+}
+
+function StorageAPI(storage) {
+  const PREFIX = "__Settings__";
+  const DEFAULT = "Default__";
+
+  const get = async (key) => {
+    return (await storage.get(PREFIX + key))[PREFIX + key];
+  }
+
+  const getAll = async () => {
+    let entries = Object.keys(await storage.get())
+      .filter(key => key.includes(PREFIX))
+      .filter((key, idx, arr) => arr.indexOf(key) === idx)
+      .map(key => key.replace(PREFIX, ""))
+      .map(key => key.replace(DEFAULT, ""))
+      .map(async key => [key, await Get(key)]);
+
+    return Object.fromEntries(await Promise.all(entries));
+  }
+
+  const Get = async (key, optionalDefault) => {
+    if (key === undefined) return await getAll();
+    return (await get(key)) ?? (await get(DEFAULT + key)) ?? optionalDefault;
+  }
+
+  const Set = async (key, value) => {
+    return (await storage.set({ [PREFIX + key]: value }));
+  }
+
+  const Remove = async (key) => {
+    return (await storage.remove(PREFIX + key));
+  }
+
+  const Defaults = async (defaults) => {
+    return Object.entries(defaults).forEach(([key, value]) => Set(DEFAULT + key, value))
+  }
+
+  const API = {
+    "Get": Get,
+    "Set": Set,
+    "Remove": Remove,
+    "Defaults": Defaults,
+  }
+
+  return API;
+};
+

--- a/wikiweaver-server/cmd/main/wikiweaver-server.go
+++ b/wikiweaver-server/cmd/main/wikiweaver-server.go
@@ -723,7 +723,7 @@ func handleExtJoin(w http.ResponseWriter, r *http.Request) {
 			if otherWithSameUsername.UserID == request.UserID || globalState.Dev {
 				successResponse := JoinToExtResponse{
 					Success:        true,
-					UserID:         request.UserID,
+					UserID:         otherWithSameUsername.UserID,
 					AlreadyInLobby: true,
 				}
 				SendResponseToExt(w, successResponse)


### PR DESCRIPTION
Chrome only allows one service worker, instead of multiple background scripts like Firefox. So to remedy that I made the settings file and background scripts into module. This makes it possible for the background script to import it. It also needed to be imported in a special way in the other files as well...

The settings library is not super efficient, but it is probably good enough.